### PR TITLE
handle static routes precedence

### DIFF
--- a/tests/tests.php
+++ b/tests/tests.php
@@ -177,6 +177,19 @@ class Tests {
         $access->allow('@admin_user_edit','user_admin_edit');
         $access->allow('@admin_user_delete','user_admin_delete');
         $test->expect(
+            $access->granted('GET /admin/user/new','superadmin') &&
+            $access->granted('GET /admin/user/23','superadmin') &&
+            $access->granted('POST /admin/user/23','superadmin') &&
+            $access->granted('POST /admin/user/new','user_admin_create') &&
+            $access->granted('POST /admin/user/23','user_admin_edit') &&
+            !$access->granted('POST /admin/user/23','client') &&
+            !$access->granted('GET /admin/user/new','user_admin_edit') &&
+            !$access->granted('POST /admin/user/new','user_admin_edit') &&
+            !$access->granted('GET /admin/user/23','user_admin_create') &&
+            !$access->granted('POST /admin/user/23','user_admin_create'),
+            'Static routes precedence'
+        );
+        $test->expect(
             $access->granted('GET /admin/user/23','superadmin') &&
             $access->granted('DELETE /admin/user/23','superadmin') &&
             $access->granted('POST /admin/user/23','user_admin_edit') &&
@@ -188,6 +201,25 @@ class Tests {
             !$access->granted('DELETE /admin/user/12','user_admin_create') &&
             !$access->granted('DELETE /admin/user/12','user_admin_edit'),
             'Named route verb inheritance'
+        );
+        $access->policy('deny');
+        $test->expect(
+            $access->granted('GET /admin/user/new','superadmin') &&
+            $access->granted('GET /admin/user/23','superadmin') &&
+            $access->granted('POST /admin/user/23','superadmin') &&
+            $access->granted('DELETE /admin/user/23','superadmin') &&
+            $access->granted('POST /admin/user/new','user_admin_create') &&
+            $access->granted('POST /admin/user/23','user_admin_edit') &&
+            $access->granted('DELETE /admin/user/23','user_admin_delete') &&
+            !$access->granted('POST /admin/user/23','client') &&
+            !$access->granted('DELETE /admin/user/23','client') &&
+            !$access->granted('GET /admin/user/new','user_admin_edit') &&
+            !$access->granted('POST /admin/user/new','user_admin_edit') &&
+            !$access->granted('GET /admin/user/23','user_admin_create') &&
+            !$access->granted('POST /admin/user/23','user_admin_create') &&
+            !$access->granted('DELETE /admin/user/12','user_admin_create') &&
+            !$access->granted('DELETE /admin/user/12','user_admin_edit'),
+            'Routes precedence & VERB test, reversed default policy'
         );
         $access=new \Access();
         $test->expect(


### PR DESCRIPTION
The plugin currently does not take static routes into account, that might overlay existing routes with dynamic tokens. So the routes precedence, that the F3 router is using, is not fully covered at this point. This commit fixes this case:

```ini
GET|POST @admin_user_new: /admin/user/new = Class->create
GET|POST @admin_user_edit: /admin/user/@id = Class->edit
```

```ini
[ACCESS]
policy = allow
[ACCESS.rules]
deny /admin* = *
allow /admin* = superadmin
allow @admin_user_new = role_user_create
allow @admin_user_edit = role_user_edit
```